### PR TITLE
fix `skimage.transform.pyramid_expand` issue

### DIFF
--- a/code/miscc/utils.py
+++ b/code/miscc/utils.py
@@ -125,7 +125,7 @@ def build_super_images(real_imgs, captions, ixtoword,
             one_map = attn[j]
             if (vis_size // att_sze) > 1:
                 one_map = \
-                    skimage.transform.pyramid_expand(one_map, sigma=20,
+                    skimage.transform.pyramid_expand(one_map, sigma=20, multichannel=True,
                                                      upscale=vis_size // att_sze)
             row_beforeNorm.append(one_map)
             minV = one_map.min()
@@ -223,7 +223,7 @@ def build_super_images2(real_imgs, captions, cap_lens, ixtoword,
             one_map = one_map * mask
             if (vis_size // att_sze) > 1:
                 one_map = \
-                    skimage.transform.pyramid_expand(one_map, sigma=20,
+                    skimage.transform.pyramid_expand(one_map, sigma=20, multichannel=True,
                                                      upscale=vis_size // att_sze)
             minV = one_map.min()
             maxV = one_map.max()


### PR DESCRIPTION
`skimage.transform.pyramid_expand` has different behaviors in python2 and python3, default `multichannel` should be `True` in python 3, otherwise, the output is (256,256,12), not the desired (256,256,3).